### PR TITLE
Added includeSubModules option to plugin configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ The directory where the app source files are located. Defaults to './src'.
 
 The root project directory. Defaults to the directory from where webpack is called.
 
+*includeSubModules*
+
+Some Aurelia modules or plugins have more than 1 file that need to be resolved (for example, when a plugin also contains an html template).
+By default, only the main file of a module is loaded. Adding this option allows you include extra files in the bundles.
+
+```javascript
+new AureliaWebpackPlugin({
+  includeSubModules: [
+    { moduleId: 'my-aurelia-plugin', include: /optional_regex/, exclude: /optional_regex/ }
+  ]
+})
+``` 
+
+Every module that needs extra files to be included is represented by one object in the array. 
+The *moduleId* field is required and the *include* and *exclude* fields are optional.
+
+> **Note**: internally, the includeSubModules feature is also used to resolve Aurelia's submodules in
+aurelia-templating-resources and aurelia-templating-router. 
+
 *contextMap*
 
 By default, the plugin scans the dependencies in package.json and creates a map object with package name

--- a/index.js
+++ b/index.js
@@ -117,10 +117,17 @@ function createResolveDependenciesFromContextMap(createContextMap, originalResol
                   var filePath = files[j];
                   var fileSubPath = filePath.substring(mainDir.length + 1);
                   
-                  var filter = module.filter || /[^\.]\.(js||html|css)$/;
+                  var include = module.include || /[^\.]\.(js||html|css)$/;
+                  var exclude = module.exclude || /[^\.]\.d\.ts$/
 
-                  if (fileSubPath.indexOf(mainFileName) === -1 && fileSubPath.match(filter)) {
-                    var subModuleKey = module.moduleId + '/' + fileSubPath.substring(0, fileSubPath.length - path.extname(fileSubPath).length);
+                  if (fileSubPath.indexOf(mainFileName) === -1 && 
+                    (fileSubPath.match(include) && ! fileSubPath.match(exclude))) {
+                    var extension = path.extname(fileSubPath);
+                    if (extension === '.js') {
+                      var extensionLessSubModuleKey = module.moduleId + '/' + fileSubPath.substring(0, fileSubPath.length - extension.length);
+                      dependencies.push(new ContextElementDependency(path.resolve(mainDir, fileSubPath), './' + extensionLessSubModuleKey));  
+                    }
+                    var subModuleKey = module.moduleId + '/' + fileSubPath;
                     dependencies.push(new ContextElementDependency(path.resolve(mainDir, fileSubPath), './' + subModuleKey));
                   }                                                             
                 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "http://github.com/aurelia/webpack-plugin"
   },
   "dependencies": {
-    "recursive-readdir-sync": "^1.0.6",
+    "recursive-readdir": "^1.3.0",
     "webpack": ">=1.12 <3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "http://github.com/aurelia/webpack-plugin"
   },
   "dependencies": {
+    "recursive-readdir-sync": "^1.0.6",
     "webpack": ">=1.12 <3"
   },
   "devDependencies": {

--- a/test/node_modules/aurelia-templating-resources/dist/commonjs/sub/sub.js
+++ b/test/node_modules/aurelia-templating-resources/dist/commonjs/sub/sub.js
@@ -1,0 +1,1 @@
+module.exports = 'aurelia-templating-resources/sub/sub';


### PR DESCRIPTION
There is a new option 'includeSubModules'. This is required for modules or plugins that come with more files than only the main file.

For example, If I want to use a plugin 'my-plugin' that also comes with html files or other js files, I need to add an entry to the webpack plugin options:

```javascript
...
new AureliaWebpackPlugin({
  includeSubModules: [
    { moduleId: 'my-plugin' }
  ]
})
``` 

All files that are in the same folder as the main file (including subfolders) will be included.