### PR TITLE
feat(package): change `webpack` to `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "dependencies": {
     "object.assign": "^4.0.3",
-    "recursive-readdir": "^1.3.0",
+    "recursive-readdir": "^1.3.0"
+  },
+  "peerDependencies": {
     "webpack": ">=1.12 <3"
   },
   "devDependencies": {


### PR DESCRIPTION
This enables the app developer to use webpack 2. You can still get

npm WARN aurelia-webpack-plugin@0.1.0 requires a peer of webpack@>=1.12 <3 but none was installed.

but the plugin will not have a local webpack version not matching the apps version.