### PR TITLE
Adding support for package.json browser field spec and test cases.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ function getContextMap(options) {
     var vendorPath = path.resolve(options.root, 'node_modules', moduleId);
     var vendorPkgPath = path.resolve(vendorPath, 'package.json');
     var vendorPkg = JSON.parse(fileSystem.readFileSync(vendorPkgPath, 'utf8'));
-    if (vendorPkg.browser || vendorPkg.main) {
-      contextMap[moduleId] = path.resolve(vendorPath, vendorPkg.browser || vendorPkg.main);
+    if (vendorPkg.main) {
+      contextMap[moduleId] = path.resolve(vendorPath, vendorPkg.main);
     }
   });
   return contextMap;


### PR DESCRIPTION
I think this covers the cases defined in the spec, but the tests fail. I'm not sure if it's web pack or this plugins' responsibility to implement the browser field spec.