### PR TITLE
fix(build-resources): Fix module resolution for symlinks

### DIFF
--- a/dist/build-resources.js
+++ b/dist/build-resources.js
@@ -218,15 +218,23 @@ var moduleRootOverride = {};
 var modulePaths = [];
 var moduleNames = [];
 
+function installedRootModulePaths() {
+  return fileSystem.readdirSync(path.join(optionsGlobal.root, 'node_modules')).filter(function (dir) {
+    return !/^\./.test(dir);
+  }).map(function (dir) {
+    return path.resolve(optionsGlobal.root, 'node_modules', dir);
+  });
+}
+
 function installedLocalModulePaths() {
   return execa('npm', ['ls', '--parseable'], { cwd: optionsGlobal.root }).then(function (res) {
-    return res.stdout.split('\n').filter(function (line, i) {
+    return installedRootModulePaths().concat(res.stdout.split('\n').filter(function (line, i) {
       return i !== 0 && !!line;
-    });
+    }));
   }).catch(function (res) {
-    return res.stdout.split('\n').filter(function (line, i) {
+    return installedRootModulePaths().concat(res.stdout.split('\n').filter(function (line, i) {
       return i !== 0 && !!line;
-    });
+    }));
   });
 }
 
@@ -417,8 +425,8 @@ function processFromPath(resources, fromPath, resource, packagePath, relativeToD
       resources[fromPathCss] = (0, _assign2.default)({}, resource, realPath, overrideBlock || {});
     }
   } else {
-      console.error('Unable to resolve', fromPath);
-    }
+    console.error('Unable to resolve', fromPath);
+  }
 }
 
 function getResourcesOfPackage() {
@@ -539,11 +547,11 @@ function fixRelativeFromPath(fromPath, realSrcPath, realParentPath, externalModu
   if (modulePathIndex !== -1) {
     return fromPath;
   } else {
-      if (fromPath.indexOf('.') == 0) {
-        fromPath = path.joinSafe('./', path.relative(realSrcPath, realParentPath), fromPath);
-      }
-      return externalModule ? path.join(externalModule, fromPath) : fromPath;
+    if (fromPath.indexOf('.') == 0) {
+      fromPath = path.joinSafe('./', path.relative(realSrcPath, realParentPath), fromPath);
     }
+    return externalModule ? path.join(externalModule, fromPath) : fromPath;
+  }
 }
 
 function resolveTemplateResources(htmlFilePath, srcPath, externalModule) {

--- a/src/build-resources.js
+++ b/src/build-resources.js
@@ -22,10 +22,16 @@ let moduleRootOverride = {};
 let modulePaths = [];
 let moduleNames = [];
 
+function installedRootModulePaths() {
+  return fileSystem.readdirSync(path.join(optionsGlobal.root, 'node_modules'))
+    .filter(dir => !(/^\./.test(dir)))
+    .map(dir => path.resolve(optionsGlobal.root, 'node_modules', dir));
+}
+
 function installedLocalModulePaths() {
   return execa('npm', ['ls', '--parseable'], { cwd: optionsGlobal.root })
-    .then(res => res.stdout.split('\n').filter((line, i) => i !== 0 && !!line))
-    .catch(res => res.stdout.split('\n').filter((line, i) => i !== 0 && !!line));
+    .then(res => installedRootModulePaths().concat(res.stdout.split('\n').filter((line, i) => i !== 0 && !!line)))
+    .catch(res => installedRootModulePaths().concat(res.stdout.split('\n').filter((line, i) => i !== 0 && !!line)));
 }
 
 function getFilesRecursively(targetDir, extension) {


### PR DESCRIPTION
Add the modules in the `node_modules` folder before resolving the modules from `npm ls --parseable`.

This is to address #44 