### PR TITLE
feat(build-resources): add an option to filter 'dependencies'

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The root project directory. Defaults to the directory from where webpack is call
 Module resource resolution is what makes Aurelia's Loader and Dependency Injection work. It's what translates require paths to places in the bundle or external files that are loaded asynchronously.
 
 Some Aurelia modules or plugins have more than 1 file that need to be resolved (for example, when a plugin also contains an html template).
-By default, the whole `src` folder their static dependencies are loaded into the loader's context.
+By default, the whole `src` folder and their static dependencies (by default, but see [includeDependencies](#includeDependencies)) are loaded into the loader's context.
 If you wish to make resources available for dynamic use, you need to explicitly `<require>` them either in your `.html` resources or from the `package.json` file.
 
 Since there are cases that cannot be supported by statically analyzing files (e.g. it is possible to generate require paths dynamically), there's an additional way to declare external dependencies, or in case of Aurelia plugins, to declare internal dependencies by listing those additional resources in the `package.json` file. Listing these dependencies in your package.json allows you include extra files in the bundles.
@@ -95,6 +95,37 @@ As you can see in the example above, it is also possible to specify that certain
 ```html
 <require from="./some-file.html" lazy bundle="other-bundle">
 ```
+
+<a name="includeDependencies"></a>
+### includeDependencies
+
+By default, all static dependencies (as listed in `package.json` under `dependencies`) are pulled into context recursively. This works fine for simple setups, but if your project also contains some node.js code (e.g. server stuff), there may be dependencies on packages which should not go into the client-bundle, because not
+only they are superfluous, but even may break bundling, if they in turn depend on node-only modules (e.g. `'fs'`).
+
+So you can narrow down these included packages by specifying `includeDependencies` in your `package.json` file. That value can contain a single glob-pattern (possibly negated by a preceding `!`) or an array of such patterns (see [matcher](https://www.npmjs.com/package/matcher) for details).
+
+Example:
+```json
+{
+  ...
+  "dependencies": {
+    ...
+    "aurelia-templating-router": "^1.0.0",
+    "yargs": "^6.0.0"
+  },
+  "aurelia": {
+    "build": {
+      "resources": [
+        ...
+      ],
+      "includeDependencies": "aurelia-*"
+    }
+  }
+}
+```
+
+Now only packages starting with `"aurelia-"` are pulled into the bundle, preventing `'yargs'` from slipping in.
+In this example the same result could be achieved by specifying `"includeDependencies": "!yargs"`.
 
 ## Example configuration: custom app directory (other than './src')
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "debug": "^2.2.0",
     "execa": "^0.4.0",
     "loader-utils": "^0.2.15",
+    "matcher": "^0.1.2",
     "object.assign": "^4.0.4",
     "recursive-readdir": "^2.0.0",
     "upath": "^0.2.0"

--- a/src/build-resources.js
+++ b/src/build-resources.js
@@ -141,18 +141,18 @@ function getPackageAureliaResources(packageJson) {
   return packageJson && packageJson.aurelia && packageJson.aurelia.build && packageJson.aurelia.build.resources || [];
 }
 
-function getPackageAureliaDepFilter(packageJson) {
-  return packageJson && packageJson.aurelia && packageJson.aurelia.build && packageJson.aurelia.build.depFilter;
+function getPackageAureliaIncludeDependencies(packageJson) {
+  return packageJson && packageJson.aurelia && packageJson.aurelia.build && packageJson.aurelia.build.includeDependencies;
 }
 
-function filterDepNames(names, filter) {
-  if (!filter) {
+function filterDepNames(names, patterns) {
+  if (!patterns) {
     return names;
   }
-  if (!Array.isArray(filter)) {
-    filter = [filter];
+  if (!Array.isArray(patterns)) {
+    patterns = [patterns];
   }
-  return matcher(names, filter);
+  return matcher(names, patterns);
 }
 
 function getPackageMainDir(packagePath) {
@@ -348,7 +348,7 @@ function getResourcesOfPackage(resources = {}, packagePath = undefined, relative
     if (packageJson.dependencies) {
       let depNames = filterDepNames(
         Object.getOwnPropertyNames(packageJson.dependencies),
-        getPackageAureliaDepFilter(packageJson)
+        getPackageAureliaIncludeDependencies(packageJson)
       );
       for (let moduleName of depNames) {
         const modulePathIndex = moduleNames.indexOf(moduleName);

--- a/test/node_modules/yargs/index.js
+++ b/test/node_modules/yargs/index.js
@@ -1,0 +1,1 @@
+module.exports = 'yargs';

--- a/test/node_modules/yargs/package.json
+++ b/test/node_modules/yargs/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "yargs",
+  "version": "6.0.0",
+  "description": "yargs the modern, pirate-themed, successor to optimist.",
+  "main": "./index.js",
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "pretest": "standard",
+    "test": "nyc --cache mocha --require ./test/before.js --timeout=8000 --check-leaks",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "release": "standard-version"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/yargs/yargs.git"
+  },
+  "homepage": "http://yargs.js.org/",
+  "standard": {
+    "ignore": [
+      "**/example/**"
+    ]
+  },
+  "keywords": [
+    "argument",
+    "args",
+    "option",
+    "parser",
+    "parsing",
+    "cli",
+    "command"
+  ],
+  "license": "MIT",
+  "engine": {
+    "node": ">=0.10"
+  },
+  "greenkeeper": {
+    "ignore": [
+      "string-width"
+    ]
+  }
+}

--- a/test/package.json
+++ b/test/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "aurelia-framework": "^1.0.0-beta.1.1.1",
     "aurelia-bootstrapper": "^1.0.0-beta.1.0.0",
-    "aurelia-templating-resources": "^1.0.0-beta.1.1.0"
+    "aurelia-templating-resources": "^1.0.0-beta.1.1.0",
+    "yargs": "^6.0.0"
   },
   "devDependencies": {
   },
@@ -22,7 +23,8 @@
         "external-3",
         "external-3/sub/resource-4",
         "external-3/sub/resource-5.html"
-      ]
+      ],
+      "depFilter": "aurelia-*"
     }
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -24,7 +24,7 @@
         "external-3/sub/resource-4",
         "external-3/sub/resource-5.html"
       ],
-      "depFilter": "aurelia-*"
+      "includeDependencies": "aurelia-*"
     }
   }
 }


### PR DESCRIPTION
As I would like to use this plugin in in my client/server projects, I stumbled across that issue:

My package.json contains packages in its "dependencies", that are needed for server stuff. Now the plugin tries to pull all that packages in the bundle. Besides the wasting of space, the plugin fails, if these packages refer to node-only packages like "fs".

This proposal would enable to shrink the list of packages to be included for dynamic laoding:

"package.json" may contain a value "aurelia.build.depFilter" to
prevent packages getting contained in the bundle.

This value may contain a glob-pattern or an array of on/off glob-pattern as provided by the npm-package "match".   

Example (package.json):

```json
{
  [...]
  "dependencies": {
    [...]
    "aurelia-templating-router": "^1.0.0",
    "yargs": "^6.0.0"
  },
  "aurelia": {
    "build": {
      "resources": [],
      "depFilter": "aurelia-*"
    }
  }
}
```

Now as only packages starting with "aurelia-" are bundled in the first place, "yargs" does no harm. The same result could be achieved by specifying ``` "depFilter": "!yargs" ```.


   
