### PR TITLE
 fix(webpack-plugin): Windows specific paths fix

### DIFF
--- a/dist/build-resources.js
+++ b/dist/build-resources.js
@@ -26,7 +26,7 @@ var _assign = require('babel-runtime/core-js/object/assign');
 var _assign2 = _interopRequireDefault(_assign);
 
 var processAll = exports.processAll = function () {
-  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(options) {
+  var ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(options) {
     var dependencies, nodeModules, packageJson;
     return _regenerator2.default.wrap(function _callee$(_context) {
       while (1) {
@@ -84,15 +84,14 @@ var processAll = exports.processAll = function () {
       }
     }, _callee, this);
   }));
-
   return function processAll(_x2) {
-    return _ref.apply(this, arguments);
+    return ref.apply(this, arguments);
   };
 }();
 
 var autoresolveTemplates = function () {
-  var _ref7 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(resources, packagePath, srcPath) {
-    var templates, srcRelativeToRoot, _iterator6, _isArray6, _i6, _ref8, htmlFilePath, templateResources, _iterator7, _isArray7, _i7, _ref9, resource;
+  var ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(resources, packagePath, srcPath) {
+    var templates, srcRelativeToRoot, _iterator6, _isArray6, _i6, _ref6, htmlFilePath, templateResources, _iterator7, _isArray7, _i7, _ref7, resource;
 
     return _regenerator2.default.wrap(function _callee2$(_context2) {
       while (1) {
@@ -120,7 +119,7 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 34);
 
           case 8:
-            _ref8 = _iterator6[_i6++];
+            _ref6 = _iterator6[_i6++];
             _context2.next = 15;
             break;
 
@@ -135,10 +134,10 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 34);
 
           case 14:
-            _ref8 = _i6.value;
+            _ref6 = _i6.value;
 
           case 15:
-            htmlFilePath = _ref8;
+            htmlFilePath = _ref6;
             templateResources = resolveTemplateResources(htmlFilePath, srcPath);
             _iterator7 = templateResources, _isArray7 = Array.isArray(_iterator7), _i7 = 0, _iterator7 = _isArray7 ? _iterator7 : (0, _getIterator3.default)(_iterator7);
 
@@ -156,7 +155,7 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 32);
 
           case 21:
-            _ref9 = _iterator7[_i7++];
+            _ref7 = _iterator7[_i7++];
             _context2.next = 28;
             break;
 
@@ -171,10 +170,10 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 32);
 
           case 27:
-            _ref9 = _i7.value;
+            _ref7 = _i7.value;
 
           case 28:
-            resource = _ref9;
+            resource = _ref7;
 
             processFromPath(resources, resource.path, resource, packagePath, srcRelativeToRoot);
 
@@ -193,9 +192,8 @@ var autoresolveTemplates = function () {
       }
     }, _callee2, this);
   }));
-
   return function autoresolveTemplates(_x8, _x9, _x10) {
-    return _ref7.apply(this, arguments);
+    return ref.apply(this, arguments);
   };
 }();
 
@@ -219,7 +217,7 @@ var modulePaths = [];
 var moduleNames = [];
 
 function installedRootModulePaths(moduleDir) {
-  var ensurePackageJson = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
+  var ensurePackageJson = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
 
   var rootModules = fileSystem.readdirSync(moduleDir).filter(function (dir) {
     return !/^\./.test(dir);
@@ -437,18 +435,18 @@ function processFromPath(resources, fromPath, resource, packagePath, relativeToD
     if (realPath) {
       var htmlResources = resolveTemplateResources(realPath.source, localSrcPath, realPath.moduleName);
       for (var _iterator = htmlResources, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : (0, _getIterator3.default)(_iterator);;) {
-        var _ref2;
+        var _ref;
 
         if (_isArray) {
           if (_i >= _iterator.length) break;
-          _ref2 = _iterator[_i++];
+          _ref = _iterator[_i++];
         } else {
           _i = _iterator.next();
           if (_i.done) break;
-          _ref2 = _i.value;
+          _ref = _i.value;
         }
 
-        var htmlResource = _ref2;
+        var htmlResource = _ref;
 
         processFromPath(resources, htmlResource.path, htmlResource, packagePath, localRelativeToDir, overrideBlock || extractBundleResourceData(htmlResource));
       }
@@ -475,16 +473,16 @@ function processFromPath(resources, fromPath, resource, packagePath, relativeToD
       resources[fromPathCss] = (0, _assign2.default)({}, resource, realPath, overrideBlock || {});
     }
   } else {
-    console.error('Unable to resolve', fromPath);
-  }
+      console.error('Unable to resolve', fromPath);
+    }
 }
 
 function getResourcesOfPackage() {
-  var resources = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
-  var packagePath = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : undefined;
-  var relativeToDir = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '';
-  var overrideBlock = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : undefined;
-  var externalModule = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : undefined;
+  var resources = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+  var packagePath = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
+  var relativeToDir = arguments.length <= 2 || arguments[2] === undefined ? '' : arguments[2];
+  var overrideBlock = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
+  var externalModule = arguments.length <= 4 || arguments[4] === undefined ? undefined : arguments[4];
 
   if (modulesProcessed.indexOf(packagePath) !== -1) {
     return;
@@ -501,34 +499,34 @@ function getResourcesOfPackage() {
   if (packageJson) {
     if (packageJson.aurelia && packageJson.aurelia.build && packageJson.aurelia.build.resources) {
       for (var _iterator2 = packageJson.aurelia.build.resources, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : (0, _getIterator3.default)(_iterator2);;) {
-        var _ref3;
+        var _ref2;
 
         if (_isArray2) {
           if (_i2 >= _iterator2.length) break;
-          _ref3 = _iterator2[_i2++];
+          _ref2 = _iterator2[_i2++];
         } else {
           _i2 = _iterator2.next();
           if (_i2.done) break;
-          _ref3 = _i2.value;
+          _ref2 = _i2.value;
         }
 
-        var resource = _ref3;
+        var resource = _ref2;
 
         resource = resource instanceof Object && !Array.isArray(resource) ? resource : { path: resource };
         var fromPaths = Array.isArray(resource.path) ? resource.path : [resource.path];
         for (var _iterator3 = fromPaths, _isArray3 = Array.isArray(_iterator3), _i3 = 0, _iterator3 = _isArray3 ? _iterator3 : (0, _getIterator3.default)(_iterator3);;) {
-          var _ref4;
+          var _ref3;
 
           if (_isArray3) {
             if (_i3 >= _iterator3.length) break;
-            _ref4 = _iterator3[_i3++];
+            _ref3 = _iterator3[_i3++];
           } else {
             _i3 = _iterator3.next();
             if (_i3.done) break;
-            _ref4 = _i3.value;
+            _ref3 = _i3.value;
           }
 
-          var fromPath = _ref4;
+          var fromPath = _ref3;
 
           debug('<' + (externalModule || path.basename(packagePath)) + '> [resolving] \'' + fromPath + '\'');
 
@@ -544,18 +542,18 @@ function getResourcesOfPackage() {
     if (packageJson.dependencies) {
       var depNames = filterDepNames((0, _getOwnPropertyNames2.default)(packageJson.dependencies), getPackageAureliaIncludeDependencies(packageJson));
       for (var _iterator4 = depNames, _isArray4 = Array.isArray(_iterator4), _i4 = 0, _iterator4 = _isArray4 ? _iterator4 : (0, _getIterator3.default)(_iterator4);;) {
-        var _ref5;
+        var _ref4;
 
         if (_isArray4) {
           if (_i4 >= _iterator4.length) break;
-          _ref5 = _iterator4[_i4++];
+          _ref4 = _iterator4[_i4++];
         } else {
           _i4 = _iterator4.next();
           if (_i4.done) break;
-          _ref5 = _i4.value;
+          _ref4 = _i4.value;
         }
 
-        var _moduleName = _ref5;
+        var _moduleName = _ref4;
 
         var _modulePathIndex = moduleNames.indexOf(_moduleName);
         if (_modulePathIndex !== -1) {
@@ -566,18 +564,18 @@ function getResourcesOfPackage() {
 
       if (!externalModule) {
         for (var _iterator5 = depNames, _isArray5 = Array.isArray(_iterator5), _i5 = 0, _iterator5 = _isArray5 ? _iterator5 : (0, _getIterator3.default)(_iterator5);;) {
-          var _ref6;
+          var _ref5;
 
           if (_isArray5) {
             if (_i5 >= _iterator5.length) break;
-            _ref6 = _iterator5[_i5++];
+            _ref5 = _iterator5[_i5++];
           } else {
             _i5 = _iterator5.next();
             if (_i5.done) break;
-            _ref6 = _i5.value;
+            _ref5 = _i5.value;
           }
 
-          var moduleName = _ref6;
+          var moduleName = _ref5;
 
           var modulePathIndex = moduleNames.indexOf(moduleName);
           if (modulePathIndex !== -1) {

--- a/dist/build-resources.js
+++ b/dist/build-resources.js
@@ -26,7 +26,7 @@ var _assign = require('babel-runtime/core-js/object/assign');
 var _assign2 = _interopRequireDefault(_assign);
 
 var processAll = exports.processAll = function () {
-  var ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(options) {
+  var _ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee(options) {
     var dependencies, nodeModules, packageJson;
     return _regenerator2.default.wrap(function _callee$(_context) {
       while (1) {
@@ -84,14 +84,15 @@ var processAll = exports.processAll = function () {
       }
     }, _callee, this);
   }));
+
   return function processAll(_x2) {
-    return ref.apply(this, arguments);
+    return _ref.apply(this, arguments);
   };
 }();
 
 var autoresolveTemplates = function () {
-  var ref = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(resources, packagePath, srcPath) {
-    var templates, srcRelativeToRoot, _iterator6, _isArray6, _i6, _ref6, htmlFilePath, templateResources, _iterator7, _isArray7, _i7, _ref7, resource;
+  var _ref7 = (0, _asyncToGenerator3.default)(_regenerator2.default.mark(function _callee2(resources, packagePath, srcPath) {
+    var templates, srcRelativeToRoot, _iterator6, _isArray6, _i6, _ref8, htmlFilePath, templateResources, _iterator7, _isArray7, _i7, _ref9, resource;
 
     return _regenerator2.default.wrap(function _callee2$(_context2) {
       while (1) {
@@ -119,7 +120,7 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 34);
 
           case 8:
-            _ref6 = _iterator6[_i6++];
+            _ref8 = _iterator6[_i6++];
             _context2.next = 15;
             break;
 
@@ -134,10 +135,10 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 34);
 
           case 14:
-            _ref6 = _i6.value;
+            _ref8 = _i6.value;
 
           case 15:
-            htmlFilePath = _ref6;
+            htmlFilePath = _ref8;
             templateResources = resolveTemplateResources(htmlFilePath, srcPath);
             _iterator7 = templateResources, _isArray7 = Array.isArray(_iterator7), _i7 = 0, _iterator7 = _isArray7 ? _iterator7 : (0, _getIterator3.default)(_iterator7);
 
@@ -155,7 +156,7 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 32);
 
           case 21:
-            _ref7 = _iterator7[_i7++];
+            _ref9 = _iterator7[_i7++];
             _context2.next = 28;
             break;
 
@@ -170,10 +171,10 @@ var autoresolveTemplates = function () {
             return _context2.abrupt('break', 32);
 
           case 27:
-            _ref7 = _i7.value;
+            _ref9 = _i7.value;
 
           case 28:
-            resource = _ref7;
+            resource = _ref9;
 
             processFromPath(resources, resource.path, resource, packagePath, srcRelativeToRoot);
 
@@ -192,8 +193,9 @@ var autoresolveTemplates = function () {
       }
     }, _callee2, this);
   }));
+
   return function autoresolveTemplates(_x8, _x9, _x10) {
-    return ref.apply(this, arguments);
+    return _ref7.apply(this, arguments);
   };
 }();
 
@@ -217,7 +219,7 @@ var modulePaths = [];
 var moduleNames = [];
 
 function installedRootModulePaths(moduleDir) {
-  var ensurePackageJson = arguments.length <= 1 || arguments[1] === undefined ? true : arguments[1];
+  var ensurePackageJson = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
 
   var rootModules = fileSystem.readdirSync(moduleDir).filter(function (dir) {
     return !/^\./.test(dir);
@@ -435,18 +437,18 @@ function processFromPath(resources, fromPath, resource, packagePath, relativeToD
     if (realPath) {
       var htmlResources = resolveTemplateResources(realPath.source, localSrcPath, realPath.moduleName);
       for (var _iterator = htmlResources, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : (0, _getIterator3.default)(_iterator);;) {
-        var _ref;
+        var _ref2;
 
         if (_isArray) {
           if (_i >= _iterator.length) break;
-          _ref = _iterator[_i++];
+          _ref2 = _iterator[_i++];
         } else {
           _i = _iterator.next();
           if (_i.done) break;
-          _ref = _i.value;
+          _ref2 = _i.value;
         }
 
-        var htmlResource = _ref;
+        var htmlResource = _ref2;
 
         processFromPath(resources, htmlResource.path, htmlResource, packagePath, localRelativeToDir, overrideBlock || extractBundleResourceData(htmlResource));
       }
@@ -473,16 +475,16 @@ function processFromPath(resources, fromPath, resource, packagePath, relativeToD
       resources[fromPathCss] = (0, _assign2.default)({}, resource, realPath, overrideBlock || {});
     }
   } else {
-      console.error('Unable to resolve', fromPath);
-    }
+    console.error('Unable to resolve', fromPath);
+  }
 }
 
 function getResourcesOfPackage() {
-  var resources = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
-  var packagePath = arguments.length <= 1 || arguments[1] === undefined ? undefined : arguments[1];
-  var relativeToDir = arguments.length <= 2 || arguments[2] === undefined ? '' : arguments[2];
-  var overrideBlock = arguments.length <= 3 || arguments[3] === undefined ? undefined : arguments[3];
-  var externalModule = arguments.length <= 4 || arguments[4] === undefined ? undefined : arguments[4];
+  var resources = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var packagePath = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : undefined;
+  var relativeToDir = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : '';
+  var overrideBlock = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : undefined;
+  var externalModule = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : undefined;
 
   if (modulesProcessed.indexOf(packagePath) !== -1) {
     return;
@@ -499,34 +501,34 @@ function getResourcesOfPackage() {
   if (packageJson) {
     if (packageJson.aurelia && packageJson.aurelia.build && packageJson.aurelia.build.resources) {
       for (var _iterator2 = packageJson.aurelia.build.resources, _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : (0, _getIterator3.default)(_iterator2);;) {
-        var _ref2;
+        var _ref3;
 
         if (_isArray2) {
           if (_i2 >= _iterator2.length) break;
-          _ref2 = _iterator2[_i2++];
+          _ref3 = _iterator2[_i2++];
         } else {
           _i2 = _iterator2.next();
           if (_i2.done) break;
-          _ref2 = _i2.value;
+          _ref3 = _i2.value;
         }
 
-        var resource = _ref2;
+        var resource = _ref3;
 
         resource = resource instanceof Object && !Array.isArray(resource) ? resource : { path: resource };
         var fromPaths = Array.isArray(resource.path) ? resource.path : [resource.path];
         for (var _iterator3 = fromPaths, _isArray3 = Array.isArray(_iterator3), _i3 = 0, _iterator3 = _isArray3 ? _iterator3 : (0, _getIterator3.default)(_iterator3);;) {
-          var _ref3;
+          var _ref4;
 
           if (_isArray3) {
             if (_i3 >= _iterator3.length) break;
-            _ref3 = _iterator3[_i3++];
+            _ref4 = _iterator3[_i3++];
           } else {
             _i3 = _iterator3.next();
             if (_i3.done) break;
-            _ref3 = _i3.value;
+            _ref4 = _i3.value;
           }
 
-          var fromPath = _ref3;
+          var fromPath = _ref4;
 
           debug('<' + (externalModule || path.basename(packagePath)) + '> [resolving] \'' + fromPath + '\'');
 
@@ -542,18 +544,18 @@ function getResourcesOfPackage() {
     if (packageJson.dependencies) {
       var depNames = filterDepNames((0, _getOwnPropertyNames2.default)(packageJson.dependencies), getPackageAureliaIncludeDependencies(packageJson));
       for (var _iterator4 = depNames, _isArray4 = Array.isArray(_iterator4), _i4 = 0, _iterator4 = _isArray4 ? _iterator4 : (0, _getIterator3.default)(_iterator4);;) {
-        var _ref4;
+        var _ref5;
 
         if (_isArray4) {
           if (_i4 >= _iterator4.length) break;
-          _ref4 = _iterator4[_i4++];
+          _ref5 = _iterator4[_i4++];
         } else {
           _i4 = _iterator4.next();
           if (_i4.done) break;
-          _ref4 = _i4.value;
+          _ref5 = _i4.value;
         }
 
-        var _moduleName = _ref4;
+        var _moduleName = _ref5;
 
         var _modulePathIndex = moduleNames.indexOf(_moduleName);
         if (_modulePathIndex !== -1) {
@@ -564,18 +566,18 @@ function getResourcesOfPackage() {
 
       if (!externalModule) {
         for (var _iterator5 = depNames, _isArray5 = Array.isArray(_iterator5), _i5 = 0, _iterator5 = _isArray5 ? _iterator5 : (0, _getIterator3.default)(_iterator5);;) {
-          var _ref5;
+          var _ref6;
 
           if (_isArray5) {
             if (_i5 >= _iterator5.length) break;
-            _ref5 = _iterator5[_i5++];
+            _ref6 = _iterator5[_i5++];
           } else {
             _i5 = _iterator5.next();
             if (_i5.done) break;
-            _ref5 = _i5.value;
+            _ref6 = _i5.value;
           }
 
-          var moduleName = _ref5;
+          var moduleName = _ref6;
 
           var modulePathIndex = moduleNames.indexOf(moduleName);
           if (modulePathIndex !== -1) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,7 +36,7 @@ function handleError(error) {
 
 var AureliaWebpackPlugin = function () {
   function AureliaWebpackPlugin() {
-    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
     (0, _classCallCheck3.default)(this, AureliaWebpackPlugin);
 
     options.root = options.root ? path.normalizeSafe(options.root) : path.dirname(module.parent.filename);
@@ -126,82 +126,84 @@ var AureliaWebpackPlugin = function () {
 
         var resourcePath = path.normalizeSafe(result.resource);
         if (self.options.src.indexOf(resourcePath, self.options.src.length - resourcePath.length) !== -1) {
-          var resolveDependencies = result.resolveDependencies;
+          (function () {
+            var resolveDependencies = result.resolveDependencies;
 
-          result.resolveDependencies = function (fs, resource, recursive, regExp, callback) {
-            return resolveDependencies(fs, resource, recursive, regExp, function (error, dependencies) {
-              if (error) return callback(error);
+            result.resolveDependencies = function (fs, resource, recursive, regExp, callback) {
+              return resolveDependencies(fs, resource, recursive, regExp, function (error, dependencies) {
+                if (error) return callback(error);
 
-              var originalDependencies = dependencies.slice();
-              dependencies = [];
+                var originalDependencies = dependencies.slice();
+                dependencies = [];
 
-              var _loop = function _loop() {
-                if (_isArray) {
-                  if (_i >= _iterator.length) return 'break';
-                  _ref = _iterator[_i++];
-                } else {
-                  _i = _iterator.next();
-                  if (_i.done) return 'break';
-                  _ref = _i.value;
-                }
-
-                var dependency = _ref;
-
-                if (dependencies.findIndex(function (cDependency) {
-                  return cDependency.userRequest === dependency.userRequest;
-                }) === -1 && !dependency.userRequest.endsWith('.ts') && !dependency.userRequest.endsWith('.js')) dependencies.push(dependency);
-              };
-
-              for (var _iterator = originalDependencies, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : (0, _getIterator3.default)(_iterator);;) {
-                var _ref;
-
-                var _ret = _loop();
-
-                if (_ret === 'break') break;
-              }
-
-              var _loop2 = function _loop2() {
-                if (_isArray2) {
-                  if (_i2 >= _iterator2.length) return 'break';
-                  _ref2 = _iterator2[_i2++];
-                } else {
-                  _i2 = _iterator2.next();
-                  if (_i2.done) return 'break';
-                  _ref2 = _i2.value;
-                }
-
-                var requireRequestPath = _ref2;
-
-                try {
-                  var _resource = contextElements[requireRequestPath];
-
-                  requireRequestPath = path.joinSafe('./', requireRequestPath);
-                  var newDependency = new ContextElementDependency(self.getPath(_resource), requireRequestPath);
-                  if (_resource.hasOwnProperty('optional')) newDependency.optional = !!_resource.optional;else newDependency.optional = true;
-                  var previouslyAdded = dependencies.findIndex(function (dependency) {
-                    return dependency.userRequest === requireRequestPath;
-                  });
-                  if (previouslyAdded > -1) {
-                    dependencies[previouslyAdded] = newDependency;
+                var _loop = function _loop() {
+                  if (_isArray) {
+                    if (_i >= _iterator.length) return 'break';
+                    _ref = _iterator[_i++];
                   } else {
-                    dependencies.push(newDependency);
+                    _i = _iterator.next();
+                    if (_i.done) return 'break';
+                    _ref = _i.value;
                   }
-                } catch (e) {
-                  handleError(e);
+
+                  var dependency = _ref;
+
+                  if (dependencies.findIndex(function (cDependency) {
+                    return cDependency.userRequest === dependency.userRequest;
+                  }) === -1 && !dependency.userRequest.endsWith('.ts') && !dependency.userRequest.endsWith('.js')) dependencies.push(dependency);
+                };
+
+                for (var _iterator = originalDependencies, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : (0, _getIterator3.default)(_iterator);;) {
+                  var _ref;
+
+                  var _ret2 = _loop();
+
+                  if (_ret2 === 'break') break;
                 }
-              };
 
-              for (var _iterator2 = (0, _keys2.default)(contextElements).reverse(), _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : (0, _getIterator3.default)(_iterator2);;) {
-                var _ref2;
+                var _loop2 = function _loop2() {
+                  if (_isArray2) {
+                    if (_i2 >= _iterator2.length) return 'break';
+                    _ref2 = _iterator2[_i2++];
+                  } else {
+                    _i2 = _iterator2.next();
+                    if (_i2.done) return 'break';
+                    _ref2 = _i2.value;
+                  }
 
-                var _ret2 = _loop2();
+                  var requireRequestPath = _ref2;
 
-                if (_ret2 === 'break') break;
-              }
+                  try {
+                    var _resource = contextElements[requireRequestPath];
 
-              return callback(null, dependencies);
-            });
-          };
+                    requireRequestPath = path.joinSafe('./', requireRequestPath);
+                    var newDependency = new ContextElementDependency(self.getPath(_resource), requireRequestPath);
+                    if (_resource.hasOwnProperty('optional')) newDependency.optional = !!_resource.optional;else newDependency.optional = true;
+                    var previouslyAdded = dependencies.findIndex(function (dependency) {
+                      return dependency.userRequest === requireRequestPath;
+                    });
+                    if (previouslyAdded > -1) {
+                      dependencies[previouslyAdded] = newDependency;
+                    } else {
+                      dependencies.push(newDependency);
+                    }
+                  } catch (e) {
+                    handleError(e);
+                  }
+                };
+
+                for (var _iterator2 = (0, _keys2.default)(contextElements).reverse(), _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : (0, _getIterator3.default)(_iterator2);;) {
+                  var _ref2;
+
+                  var _ret3 = _loop2();
+
+                  if (_ret3 === 'break') break;
+                }
+
+                return callback(null, dependencies);
+              });
+            };
+          })();
         }
         return callback(null, result);
       });
@@ -256,41 +258,43 @@ var AureliaWebpackPlugin = function () {
           }
 
           if (typeof module.resource == 'string') {
-            var moduleId = void 0;
+            (function () {
+              var moduleId = void 0;
 
-            if (options.nameLocalModules) {
-              if (path.normalize(module.resource).startsWith(options.src)) {
-                var relativeToSrc = path.relative(options.src, module.resource);
-                moduleId = relativeToSrc;
+              if (options.nameLocalModules) {
+                if (module.resource.startsWith(options.src)) {
+                  var relativeToSrc = path.relative(options.src, module.resource);
+                  moduleId = relativeToSrc;
+                }
               }
-            }
-            if (options.nameExternalModules) {
-              if (!moduleId && typeof module.userRequest == 'string') {
-                var matchingModuleIds = paths.filter(function (originPath) {
-                  return contextElements[originPath].source === path.normalize(module.userRequest);
-                }).map(function (originPath) {
-                  return path.normalize(originPath);
-                });
-
-                if (matchingModuleIds.length) {
-                  matchingModuleIds.sort(function (a, b) {
-                    return b.length - a.length;
+              if (options.nameExternalModules) {
+                if (!moduleId && typeof module.userRequest == 'string') {
+                  var matchingModuleIds = paths.filter(function (originPath) {
+                    return contextElements[originPath].source === module.userRequest;
+                  }).map(function (originPath) {
+                    return path.normalize(originPath);
                   });
-                  moduleId = matchingModuleIds[0];
+
+                  if (matchingModuleIds.length) {
+                    matchingModuleIds.sort(function (a, b) {
+                      return b.length - a.length;
+                    });
+                    moduleId = matchingModuleIds[0];
+                  }
+                }
+                if (!moduleId && typeof module.rawRequest == 'string' && module.rawRequest.indexOf('.') !== 0) {
+                  var index = paths.indexOf(module.rawRequest);
+                  if (index >= 0) {
+                    moduleId = module.rawRequest;
+                  }
                 }
               }
-              if (!moduleId && typeof module.rawRequest == 'string' && module.rawRequest.indexOf('.') !== 0) {
-                var index = paths.indexOf(module.rawRequest);
-                if (index >= 0) {
-                  moduleId = module.rawRequest;
-                }
+              if (moduleId && !modules.find(function (m) {
+                return m.id === moduleId;
+              })) {
+                module.id = moduleId;
               }
-            }
-            if (moduleId && !modules.find(function (m) {
-              return m.id === moduleId;
-            })) {
-              module.id = moduleId;
-            }
+            })();
           }
         });
       });

--- a/dist/index.js
+++ b/dist/index.js
@@ -36,7 +36,7 @@ function handleError(error) {
 
 var AureliaWebpackPlugin = function () {
   function AureliaWebpackPlugin() {
-    var options = arguments.length <= 0 || arguments[0] === undefined ? {} : arguments[0];
+    var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
     (0, _classCallCheck3.default)(this, AureliaWebpackPlugin);
 
     options.root = options.root ? path.normalizeSafe(options.root) : path.dirname(module.parent.filename);
@@ -126,84 +126,82 @@ var AureliaWebpackPlugin = function () {
 
         var resourcePath = path.normalizeSafe(result.resource);
         if (self.options.src.indexOf(resourcePath, self.options.src.length - resourcePath.length) !== -1) {
-          (function () {
-            var resolveDependencies = result.resolveDependencies;
+          var resolveDependencies = result.resolveDependencies;
 
-            result.resolveDependencies = function (fs, resource, recursive, regExp, callback) {
-              return resolveDependencies(fs, resource, recursive, regExp, function (error, dependencies) {
-                if (error) return callback(error);
+          result.resolveDependencies = function (fs, resource, recursive, regExp, callback) {
+            return resolveDependencies(fs, resource, recursive, regExp, function (error, dependencies) {
+              if (error) return callback(error);
 
-                var originalDependencies = dependencies.slice();
-                dependencies = [];
+              var originalDependencies = dependencies.slice();
+              dependencies = [];
 
-                var _loop = function _loop() {
-                  if (_isArray) {
-                    if (_i >= _iterator.length) return 'break';
-                    _ref = _iterator[_i++];
-                  } else {
-                    _i = _iterator.next();
-                    if (_i.done) return 'break';
-                    _ref = _i.value;
-                  }
-
-                  var dependency = _ref;
-
-                  if (dependencies.findIndex(function (cDependency) {
-                    return cDependency.userRequest === dependency.userRequest;
-                  }) === -1 && !dependency.userRequest.endsWith('.ts') && !dependency.userRequest.endsWith('.js')) dependencies.push(dependency);
-                };
-
-                for (var _iterator = originalDependencies, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : (0, _getIterator3.default)(_iterator);;) {
-                  var _ref;
-
-                  var _ret2 = _loop();
-
-                  if (_ret2 === 'break') break;
+              var _loop = function _loop() {
+                if (_isArray) {
+                  if (_i >= _iterator.length) return 'break';
+                  _ref = _iterator[_i++];
+                } else {
+                  _i = _iterator.next();
+                  if (_i.done) return 'break';
+                  _ref = _i.value;
                 }
 
-                var _loop2 = function _loop2() {
-                  if (_isArray2) {
-                    if (_i2 >= _iterator2.length) return 'break';
-                    _ref2 = _iterator2[_i2++];
-                  } else {
-                    _i2 = _iterator2.next();
-                    if (_i2.done) return 'break';
-                    _ref2 = _i2.value;
-                  }
+                var dependency = _ref;
 
-                  var requireRequestPath = _ref2;
+                if (dependencies.findIndex(function (cDependency) {
+                  return cDependency.userRequest === dependency.userRequest;
+                }) === -1 && !dependency.userRequest.endsWith('.ts') && !dependency.userRequest.endsWith('.js')) dependencies.push(dependency);
+              };
 
-                  try {
-                    var _resource = contextElements[requireRequestPath];
+              for (var _iterator = originalDependencies, _isArray = Array.isArray(_iterator), _i = 0, _iterator = _isArray ? _iterator : (0, _getIterator3.default)(_iterator);;) {
+                var _ref;
 
-                    requireRequestPath = path.joinSafe('./', requireRequestPath);
-                    var newDependency = new ContextElementDependency(self.getPath(_resource), requireRequestPath);
-                    if (_resource.hasOwnProperty('optional')) newDependency.optional = !!_resource.optional;else newDependency.optional = true;
-                    var previouslyAdded = dependencies.findIndex(function (dependency) {
-                      return dependency.userRequest === requireRequestPath;
-                    });
-                    if (previouslyAdded > -1) {
-                      dependencies[previouslyAdded] = newDependency;
-                    } else {
-                      dependencies.push(newDependency);
-                    }
-                  } catch (e) {
-                    handleError(e);
-                  }
-                };
+                var _ret = _loop();
 
-                for (var _iterator2 = (0, _keys2.default)(contextElements).reverse(), _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : (0, _getIterator3.default)(_iterator2);;) {
-                  var _ref2;
+                if (_ret === 'break') break;
+              }
 
-                  var _ret3 = _loop2();
-
-                  if (_ret3 === 'break') break;
+              var _loop2 = function _loop2() {
+                if (_isArray2) {
+                  if (_i2 >= _iterator2.length) return 'break';
+                  _ref2 = _iterator2[_i2++];
+                } else {
+                  _i2 = _iterator2.next();
+                  if (_i2.done) return 'break';
+                  _ref2 = _i2.value;
                 }
 
-                return callback(null, dependencies);
-              });
-            };
-          })();
+                var requireRequestPath = _ref2;
+
+                try {
+                  var _resource = contextElements[requireRequestPath];
+
+                  requireRequestPath = path.joinSafe('./', requireRequestPath);
+                  var newDependency = new ContextElementDependency(self.getPath(_resource), requireRequestPath);
+                  if (_resource.hasOwnProperty('optional')) newDependency.optional = !!_resource.optional;else newDependency.optional = true;
+                  var previouslyAdded = dependencies.findIndex(function (dependency) {
+                    return dependency.userRequest === requireRequestPath;
+                  });
+                  if (previouslyAdded > -1) {
+                    dependencies[previouslyAdded] = newDependency;
+                  } else {
+                    dependencies.push(newDependency);
+                  }
+                } catch (e) {
+                  handleError(e);
+                }
+              };
+
+              for (var _iterator2 = (0, _keys2.default)(contextElements).reverse(), _isArray2 = Array.isArray(_iterator2), _i2 = 0, _iterator2 = _isArray2 ? _iterator2 : (0, _getIterator3.default)(_iterator2);;) {
+                var _ref2;
+
+                var _ret2 = _loop2();
+
+                if (_ret2 === 'break') break;
+              }
+
+              return callback(null, dependencies);
+            });
+          };
         }
         return callback(null, result);
       });
@@ -258,43 +256,41 @@ var AureliaWebpackPlugin = function () {
           }
 
           if (typeof module.resource == 'string') {
-            (function () {
-              var moduleId = void 0;
+            var moduleId = void 0;
 
-              if (options.nameLocalModules) {
-                if (module.resource.startsWith(options.src)) {
-                  var relativeToSrc = path.relative(options.src, module.resource);
-                  moduleId = relativeToSrc;
-                }
+            if (options.nameLocalModules) {
+              if (path.normalize(module.resource).startsWith(options.src)) {
+                var relativeToSrc = path.relative(options.src, module.resource);
+                moduleId = relativeToSrc;
               }
-              if (options.nameExternalModules) {
-                if (!moduleId && typeof module.userRequest == 'string') {
-                  var matchingModuleIds = paths.filter(function (originPath) {
-                    return contextElements[originPath].source === module.userRequest;
-                  }).map(function (originPath) {
-                    return path.normalize(originPath);
+            }
+            if (options.nameExternalModules) {
+              if (!moduleId && typeof module.userRequest == 'string') {
+                var matchingModuleIds = paths.filter(function (originPath) {
+                  return contextElements[originPath].source === path.normalize(module.userRequest);
+                }).map(function (originPath) {
+                  return path.normalize(originPath);
+                });
+
+                if (matchingModuleIds.length) {
+                  matchingModuleIds.sort(function (a, b) {
+                    return b.length - a.length;
                   });
-
-                  if (matchingModuleIds.length) {
-                    matchingModuleIds.sort(function (a, b) {
-                      return b.length - a.length;
-                    });
-                    moduleId = matchingModuleIds[0];
-                  }
-                }
-                if (!moduleId && typeof module.rawRequest == 'string' && module.rawRequest.indexOf('.') !== 0) {
-                  var index = paths.indexOf(module.rawRequest);
-                  if (index >= 0) {
-                    moduleId = module.rawRequest;
-                  }
+                  moduleId = matchingModuleIds[0];
                 }
               }
-              if (moduleId && !modules.find(function (m) {
-                return m.id === moduleId;
-              })) {
-                module.id = moduleId;
+              if (!moduleId && typeof module.rawRequest == 'string' && module.rawRequest.indexOf('.') !== 0) {
+                var index = paths.indexOf(module.rawRequest);
+                if (index >= 0) {
+                  moduleId = module.rawRequest;
+                }
               }
-            })();
+            }
+            if (moduleId && !modules.find(function (m) {
+              return m.id === moduleId;
+            })) {
+              module.id = moduleId;
+            }
           }
         });
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-webpack-plugin",
-  "version": "1.2.1",
+  "version": "1.2.2-rc.1",
   "description": "A plugin for webpack that enables bundling Aurelia applications.",
   "keywords": [
     "aurelia",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-webpack-plugin",
-  "version": "1.2.2-rc.1",
+  "version": "1.2.2",
   "description": "A plugin for webpack that enables bundling Aurelia applications.",
   "keywords": [
     "aurelia",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-webpack-plugin",
-  "version": "1.2.2",
+  "version": "1.2.1",
   "description": "A plugin for webpack that enables bundling Aurelia applications.",
   "keywords": [
     "aurelia",

--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ class AureliaWebpackPlugin {
             let moduleId;
             
             if (options.nameLocalModules) {
-              if (module.resource.startsWith(options.src)) {
+              if (path.normalize(module.resource).startsWith(options.src)) {
                 // paths inside SRC
                 let relativeToSrc = path.relative(options.src, module.resource);
                 moduleId = relativeToSrc;
@@ -223,7 +223,7 @@ class AureliaWebpackPlugin {
               if (!moduleId && typeof module.userRequest == 'string') {
                 // paths resolved as build resources
                 let matchingModuleIds = paths
-                  .filter(originPath => contextElements[originPath].source === module.userRequest)
+                  .filter(originPath => contextElements[originPath].source === path.normalize(module.userRequest))
                   .map(originPath => path.normalize(originPath));
 
                 if (matchingModuleIds.length) {

--- a/test/index.js
+++ b/test/index.js
@@ -27,13 +27,12 @@ describe('Aurelia webpack plugin', function () {
     };
     
     webpack(config, function (err, stats) {
-      expect(err).to.be.falsy;
-      expect(stats.hasErrors()).to.be.falsy;
-      expect(stats.hasWarnings()).to.be.falsy;
+      expect(err).to.be.null;
+      // Do not allow any errors, warnings are ok though
+      expect(stats.hasErrors()).to.be.false;
       
-      expect(fs.existsSync(path.join(OUTPUT_DIR, '1.bundle.js'))).to.be.truthy;
-
-      // todo try to require from bundle
+      expect(fs.existsSync(path.join(OUTPUT_DIR, 'bundle.js'))).to.be.true;
+      expect(fs.existsSync(path.join(OUTPUT_DIR, '0.bundle.js'))).to.be.true;
       
       done();
     });


### PR DESCRIPTION
fixed an issue where paths weren't correctly normalized, causing the resulting bundle to contain moduleId's as integers instead of their names when packed on a windows machine