### PR TITLE
fix(package): add "types" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     }
   ],
   "main": "dist/index.js",
+  "types": "dist/types/index.d.ts",
   "files": [ "dist", "runtime" ],
   "scripts": {
     "build": "tsc"


### PR DESCRIPTION
The distribution includes a "types" declaration directory, however this
was not identified in the [package.json file](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package). This commit adds the
"types" field, pointing to "dist/types/index.d.ts".