### PR TITLE
fix(webpack): remove runtime insertion hack from webpack 3 or below e…

### DIFF
--- a/src/AureliaPlugin.ts
+++ b/src/AureliaPlugin.ts
@@ -216,14 +216,17 @@ export class AureliaPlugin {
     let webpackEntry = options.entry;
     let entries = Array.isArray(modules) ? modules : [modules];
     if (typeof webpackEntry == "object" && !Array.isArray(webpackEntry)) {
-      // There are multiple entries defined in the config
-      // Unless there was a particular configuration, we modify the first one
-      // (note that JS enumerates props in the same order they were declared)
-      // Modifying the first one only plays nice with the common pattern
-      // `entry: { main, vendor }` some people use.
-      let ks = this.options.entry || Object.keys(webpackEntry)[0];
-      if (!Array.isArray(ks)) ks = [ks];
-      ks.forEach(k => webpackEntry[k] = entries.concat(webpackEntry[k]));
+      // Add runtime to each entry
+      for (let k in webpackEntry) {
+        if (!webpackEntry.hasOwnProperty(k)) {
+          continue;
+        }
+        let entry = webpackEntry[k];
+        if (!Array.isArray(entry)) {
+          entry = [entry];
+        }
+        webpackEntry[k] = entries.concat(entry);
+      }
     }
     else
       options.entry = entries.concat(webpackEntry);

--- a/src/AureliaPlugin.ts
+++ b/src/AureliaPlugin.ts
@@ -215,17 +215,29 @@ export class AureliaPlugin {
   addEntry(options: Webpack.Options, modules: string|string[]) {
     let webpackEntry = options.entry;
     let entries = Array.isArray(modules) ? modules : [modules];
-    if (typeof webpackEntry == "object" && !Array.isArray(webpackEntry)) {
-      // Add runtime to each entry
-      for (let k in webpackEntry) {
-        if (!webpackEntry.hasOwnProperty(k)) {
-          continue;
+    if (typeof webpackEntry === "object" && !Array.isArray(webpackEntry)) {
+      if (this.options.entry) {
+        // Add runtime only to the entries defined on this plugin
+        let ks = this.options.entry;
+        if (!Array.isArray(ks)) ks = [ks];
+        ks.forEach(k => {
+          if (webpackEntry[k] === undefined) {
+            throw new Error('entry key "' + k + '" is not defined in Webpack build, cannot apply runtime.');
+          }
+          webpackEntry[k] = entries.concat(webpackEntry[k])
+        });
+      } else {
+        // Add runtime to each entry
+        for (let k in webpackEntry) {
+          if (!webpackEntry.hasOwnProperty(k)) {
+            continue;
+          }
+          let entry = webpackEntry[k];
+          if (!Array.isArray(entry)) {
+            entry = [entry];
+          }
+          webpackEntry[k] = entries.concat(entry);
         }
-        let entry = webpackEntry[k];
-        if (!Array.isArray(entry)) {
-          entry = [entry];
-        }
-        webpackEntry[k] = entries.concat(entry);
       }
     }
     else


### PR DESCRIPTION
fix(webpack): remove runtime insertion hack from webpack 3 or below era, wherein only the first "entry" item had the runtime appended to it.

This was originally implemented to avoid adding the runtime to the secondary "vendor" entry. Using "vendor" entry points which is no longer recommended for Webpack 4 and up.

Fixes #157 