### PR TITLE
Correct support of Options.entry, use only first webpack entry point …

### DIFF
--- a/src/AureliaPlugin.ts
+++ b/src/AureliaPlugin.ts
@@ -92,11 +92,11 @@ export class AureliaPlugin {
       noModulePathResolve: false,
       noWebpackLoader: false,
       // Ideally we would like _not_ to process conventions in node_modules,
-      // because they should be using @useView and not rely in convention in 
+      // because they should be using @useView and not rely in convention in
       // the first place. Unfortunately at this point many libs do use conventions
       // so it's just more helpful for users to process them.
       // As unlikely as it may seem, a common offender here is tslib, which has
-      // matching (yet unrelated) html files in its distribution. So I am making 
+      // matching (yet unrelated) html files in its distribution. So I am making
       // a quick exception for that.
       viewsFor: "**/!(tslib)*.{ts,js}",
       viewsExtensions: ".html",
@@ -189,7 +189,7 @@ export class AureliaPlugin {
       needsEmptyEntry = true;
     }
     else if (opts.aureliaApp) {
-      // Add aurelia-app entry point. 
+      // Add aurelia-app entry point.
       // When using includeAll, we assume it's already included
       globalDependencies.push({ name: opts.aureliaApp, exports: ["configure"] });
     }
@@ -213,7 +213,7 @@ export class AureliaPlugin {
 
     if (!opts.noHtmlLoader) {
       // Ensure that we trace HTML dependencies (always required because of 3rd party libs)
-      // Note that this loader will be in last place, which is important 
+      // Note that this loader will be in last place, which is important
       // because it will process the file first, before any other loader.
       compiler.options.module.rules.push({ test: /\.html?$/i, use: "aurelia-webpack-plugin/html-requires-loader" });
     }
@@ -267,9 +267,18 @@ export class AureliaPlugin {
     if (typeof webpackEntry === 'function') {
       return;
     }
+
+    // If entry point unspecified in plugin options; use the first webpack entry point
+    const pluginEntry = this.options.entry ?? [Object.keys(webpackEntry)[0]];
+
+    // Ensure array
+    const pluginEntries = Array.isArray(pluginEntry) ? pluginEntry : [pluginEntry];
+
     // Add runtime to each entry
-    for (let k in webpackEntry) {
-      if (this.options.entry?.includes(k) ?? false) {
+    for (const k of pluginEntries) {
+
+      // Verify that plugin options entry points are defined in webpack entry points
+      if (!(k in webpackEntry)) {
         throw new Error('entry key "' + k + '" is not defined in Webpack build, cannot apply runtime.');
       }
       let entry = webpackEntry[k];


### PR DESCRIPTION
This PR fixes a presumed unintentional change introduced in aurelia-webpack-plugin 5.0.0.

From the documentation of the `entry` property for the plugin options ([link to Wiki page](https://github.com/aurelia/webpack-plugin/wiki/AureliaPlugin-options)):

> ### _entry_ ###
> _`entry: undefined | string | string[] = undefined`_
>
> _[...]_ 
> 
> _If you have multiple entry points, it adds them to the first one._
> 
> _If you need to change that behavior, you can use this option to specify which entry point(s) AureliaPlugin should target. Note that this option expects an entry name, not a module name._ 
> 
> _[...]_

So when plugin options `entry` property is **undefined**, the aurelia plugin should be applied only to the first webpack entry point.
When it is **defined** (string or string array), the aurelia plugin should be applied to the given webpack entry points only.

When upgrading to webpack 5, I found that this behavior had changed to something that was not in line with the documentation. When having more than one entry point in the webpack configuration, an error is thrown regardless of whether `options.entry` is defined or not. It looks like the `entry` property of the plugin options is ignored.

In our apps we normally have two webpack entry points, and we want the aurelia plugin to be applied only to one of them. That's how it worked in the webpack 4 version of the plugin. It worked when the webpack entry point for the aurelia app was the first, but to be explicit we also specified the entry point only in the plugin options `entry` property. Both things worked.

The implementation change in this PR should be more in line with the documentation and ensure better backward compatibility with the webpack 4 version of the plugin. The proposed change in this PR has been tested with our apps and fixes our issues. 

This PR fixes the last of the issues we have found when migrating our applications to webpack 5. Hoping that the PR will be approved and hoping for a new release of this plugin plus **aurelia-loader-webpack** ASAP, so that we can finalize the migration! 😃   

_Note: I did not build and commit changes to the `/dist` folder in this PR. Let me know if you also want me to build/commit/push these artifacts as well._