### PR TITLE
Fixed minimatch file matching when using pnpm

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   Core:
     runs-on: windows-latest

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -48,3 +48,14 @@ jobs:
       - name: Test build app with store plugin
         working-directory: ./tests/app-plugin-store
         run: npm run build:ci
+jobs:
+  PNPM:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 6.0.2
+      - name: Test build basic app with PNPM
+        working-directory: ./tests/app-pnpm
+        run: npm run build:ci

--- a/src/ConventionDependenciesPlugin.ts
+++ b/src/ConventionDependenciesPlugin.ts
@@ -36,7 +36,7 @@ export class ConventionDependenciesPlugin extends BaseIncludePlugin {
       if (/^async[!?]/.test(rawRequest)) {
         return;
       }
-      if (!minimatch(path.relative(root, file), this.glob)) {
+      if (!minimatch(path.relative(root, file), this.glob, {dot: true})) {
         return;
       }
 

--- a/tests/app-pnpm/index.ejs
+++ b/tests/app-pnpm/index.ejs
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset='UTF-8'>
+  <meta name='viewport' content='width=device-width, initial-scale=1.0'>
+  <meta http-equiv='X-UA-Compatible' content='ie=edge'>
+  <title>Aurelia app</title>
+</head>
+<body>
+  <div aurelia-app='main'></div>
+</body>
+</html>

--- a/tests/app-pnpm/package.json
+++ b/tests/app-pnpm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "app-basic",
+  "scripts": {
+    "dev": "webpack-dev-server",
+    "build": "webpack --stats-error-details",
+    "build:prod": "webpack --mode=production",
+    "prebuild:ci": "pnpm install",
+    "build:ci": "pnpm run build -- --no-stats",
+    "rimraf": "rimraf dist/**/*.js"
+  },
+  "dependencies": {
+    "aurelia-webpack-plugin": "file:../.."
+  }
+}

--- a/tests/app-pnpm/src/app.html
+++ b/tests/app-pnpm/src/app.html
@@ -1,0 +1,4 @@
+<template>
+  Hello, how are you feeling today ${appDate.toJSON()}:
+  <img src='static/feelings-wheel.jpg' style='display: block; width: 100%;'>
+</template>

--- a/tests/app-pnpm/src/app.ts
+++ b/tests/app-pnpm/src/app.ts
@@ -1,0 +1,3 @@
+export class App {
+  appDate: Date = new Date();
+}

--- a/tests/app-pnpm/src/main.ts
+++ b/tests/app-pnpm/src/main.ts
@@ -1,0 +1,9 @@
+import { Aurelia, PLATFORM } from 'aurelia-framework';
+
+export async function configure(aurelia: Aurelia) {
+  aurelia.use
+    .basicConfiguration();
+
+  await aurelia.start();
+  await aurelia.setRoot(PLATFORM.moduleName('app'));
+}

--- a/tests/app-pnpm/tsconfig.json
+++ b/tests/app-pnpm/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "baseUrl": "src",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "lib": [
+      "dom",
+      "es2017"
+    ]
+  }
+}

--- a/tests/app-pnpm/webpack.config.js
+++ b/tests/app-pnpm/webpack.config.js
@@ -1,0 +1,58 @@
+const { AureliaPlugin } = require('aurelia-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const path = require('path');
+
+Error.stackTraceLimit = Infinity;
+
+/**
+ * @returns {import('webpack').Configuration}
+ */
+module.exports = (env = {}) => {
+  return {
+    mode: 'development',
+    target: 'web',
+    resolve: {
+      extensions: [".ts", ".js"],
+      modules: [
+        // this is only needed inside for the tests in this repo
+        // in normal application, can just use "src" instead of an absolute path to it
+        path.resolve(__dirname, "src"),
+        'node_modules'
+      ]
+    },
+    entry: {
+      // application entry file is app
+      app: ["aurelia-bootstrapper"],
+    },
+    output: {
+      // If production, add a hash to burst cache
+      filename: '[name].js'
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: 'ts-loader',
+          exclude: /node_modules/
+        },
+        {
+          test: /\.html$/,
+          loader: 'html-loader',
+          options: {
+            attrs: false
+          }
+        }
+      ]
+    },
+    plugins: [
+      new AureliaPlugin({
+        aureliaConfig: ['basic'],
+      }),
+      // Standard plugin to build index.html
+      new HtmlWebpackPlugin({
+        template: 'index.ejs'
+      })
+    ]
+  };
+};


### PR DESCRIPTION
Resolved issue in the ConventionDependenciesPlugin where file paths that contain a `.` were not matched. This prevented the usage of pnpm since all node_modules are in the `.pnpm` subfolder as illustrated [here](https://github.com/aurelia-ui-toolkits/aurelia-kendoui-bridge/issues/807).