### PR TITLE
Fixed relative path matching issue in ConventionDependenciesPlugin

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Test build app with store plugin
         working-directory: ./tests/app-plugin-store
         run: npm run build:ci
-jobs:
+
   PNPM:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fixed issue where minimatch would not match relative paths starting with `../` by feeding it resolved file paths. 
This caused issues in pnpm monorepos where Aurelia views of plugins were not included in the bundle because because they were wrongly disregarded.