### PR TITLE
fix: broken webpack mangling of harmony imports in production mode

### DIFF
--- a/src/IncludeDependency.ts
+++ b/src/IncludeDependency.ts
@@ -21,7 +21,7 @@ export class IncludeDependency extends webpack.dependencies.ModuleDependency {
   getReferencedExports(moduleGraph: webpack.ModuleGraph): (string[] | ReferencedExport)[] {
     // when there's no specific exports are targetted,
     // passing an empty array means preserving all
-    return [{ name: this.options?.exports ?? [], canMangle: false }]
+    return require("webpack").Dependency.EXPORTS_OBJECT_REFERENCED
   }
 
   get [preserveModuleName]() {


### PR DESCRIPTION
There is an issue when bundling code with imported aurelia dependency via harmony import. The code like:

import { ConsoleAppender } from 'aurelia-logging-console'
console.log(ConsoleAppender)
bundles into something like:

var a=r("aurelia-logging-console")
console.log(a.A)
while aurelia-logging-console isn't mangled itself to match the export names, so i.I is undefined.

This fix seem to work for all such cases but I am not sure if the original approach was written in such way for some specific cases which I might not be aware of so better to be investigated by core team.There is an issue when bundling code with imported aurelia dependency via harmony import. The code like:

import { ConsoleAppender } from 'aurelia-logging-console'
console.log(ConsoleAppender)
bundles into something like:

var a=r("aurelia-logging-console")
console.log(a.A)
while aurelia-logging-console isn't mangled itself to match the export names, so i.I is undefined.

This fix seem to work for all such cases but I am not sure if the original approach was written in such way for some specific cases which I might not be aware of so better to be investigated by core team.

Credits to @alexander-akait for pointing this out!